### PR TITLE
Session hash should only be generated once per session.

### DIFF
--- a/PokemonGo.RocketAPI/ISettings.cs
+++ b/PokemonGo.RocketAPI/ISettings.cs
@@ -1,4 +1,5 @@
-﻿using PokemonGo.RocketAPI.Enums;
+﻿using Google.Protobuf;
+using PokemonGo.RocketAPI.Enums;
 
 namespace PokemonGo.RocketAPI
 {
@@ -26,6 +27,7 @@ namespace PokemonGo.RocketAPI
         string FirmwareTags { get; set; }
         string FirmwareType { get; set; }
         string FirmwareFingerprint { get; set; }
+        ByteString SessionHash { get; set; }
         bool UseProxy { get; set; }
         bool UseProxyAuthentication { get; set; }
         string UseProxyHost { get; set; }


### PR DESCRIPTION
Session hash is only generated once per session in official PokemonGo client, but Rocket API is generating it each time request is built.  This change store the session hash so that it is generated once and re-used by all requests after that.